### PR TITLE
EZworkEra v3.8.1 판올림 - 모드설정 관련 핫픽스

### DIFF
--- a/Core/Ctrltool/erbcore.py
+++ b/Core/Ctrltool/erbcore.py
@@ -827,7 +827,7 @@ class ERBFunc:
                         continue
                     else:
                         dup_list.append(context)
-                if opt & 0b100: # 공백 처리안함
+                if opt & 0b1000: # 공백 처리안함
                     if not context:
                         continue
     

--- a/Core/usefile.py
+++ b/Core/usefile.py
@@ -512,7 +512,7 @@ class MenuPreset:
                 break
             elif sel_menu_num:
                 mod_name = mod_no_menudict[sel_menu_num]
-                real_no = 2 ** (sel_menu_num - 1)
+                real_no = 2 ** sel_menu_num
                 result_no = result_no ^ real_no
                 if "(선택됨)" in mod_name:
                     mod_no_menudict[sel_menu_num] = mod_name.replace("(선택됨)", "")


### PR DESCRIPTION
## 해결된 버그

* 모드 선택 관련 메뉴 항목이 2개 이상인 경우 선택한 모드가 제대로 처리되지 않던 문제를 수정.
* ERB 구상 추출 기능 사용시 공백 관련 처리 모드 선택시 제대로 작동하지 않던 점을 수정.